### PR TITLE
Bugfixes for New Add Comics Page

### DIFF
--- a/add.php
+++ b/add.php
@@ -150,7 +150,7 @@
           <div class="success-message">
             <div class="row">
               <div class="col-md-3 col-xs-hidden">
-                <img src="/images/<?php echo $cover_image_file; ?>" alt="<?php echo $series_name . '(Vol ' . $series_vol . ') #' . $issue_number; ?> Cover" class="" />
+                <img src="<?php echo $cover_image_file; ?>" alt="<?php echo $series_name . '(Vol ' . $series_vol . ') #' . $issue_number; ?> Cover" class="" />
               </div>
               <div class="col-xs-12 col-md-9">
                 <h3><?php echo $series_name; ?> <small>(Vol <?php echo $series_vol; ?>)</small> #<?php echo $issue_number; ?></h2>

--- a/admin/formprocess.php
+++ b/admin/formprocess.php
@@ -141,8 +141,8 @@
             $wiki->comicDetails ( $wiki_id );
 
             $release_date = $releaseDateArray[0] . "-" . $releaseDateArray[1] . "-" . $releaseDateArray[2];
-            $plot = htmlspecialchars($wiki->synopsis);
-            $story_name = $wiki->storyName;
+            $plot = addslashes( $wiki->synopsis );
+            $story_name = addslashes( $wiki->storyName );
             $cover_image = $wiki->coverURL;
 
             if ($cover_image == 'assets/nocover.jpg') {

--- a/admin/formprocess.php
+++ b/admin/formprocess.php
@@ -70,8 +70,10 @@
           $release_date = $released_date;
         }
 
-        if ($cover_image) {
-          $path = __ROOT__ . '/images/' . $cover_image_file;
+        if ($cover_image == 'assets/nocover.jpg') {
+          $cover_image_file = 'assets/nocover.jpg';
+        } else {
+          $path = __ROOT__ . '/' . $cover_image_file;
           $wiki = new wikiQuery();
           $wiki->downloadFile ( $cover_image, $path );
         }
@@ -89,7 +91,7 @@
           }
         } else {
           $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, original_purchase, wiki_id, wikiUpdated)
-          VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', 'images/$cover_image_file', '$original_purchase', '$wiki_id', 1)";
+          VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', '$cover_image_file', '$original_purchase', '$wiki_id', 1)";
           if (mysqli_query ( $connection, $sql )) {
             $comic_id = mysqli_insert_id($connection);
             // Add to user_comics table
@@ -135,13 +137,23 @@
             $wiki = new wikiQuery();
             $wiki->wikiSearch($query, 1);
             $wiki_id = $wiki->wiki_id;
-            
+            $wiki->comicCover( $wiki_id );
             $wiki->comicDetails ( $wiki_id );
+
             $release_date = $releaseDateArray[0] . "-" . $releaseDateArray[1] . "-" . $releaseDateArray[2];
             $plot = htmlspecialchars($wiki->synopsis);
             $story_name = $wiki->storyName;
-            $cover_image_file = $wiki->comicCover( $wiki_id );
-            $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, original_purchase, wiki_id, wikiUpdated) VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', 'images/$cover_image_file', '$original_purchase', '$wiki_id', 1)";
+            $cover_image = $wiki->coverURL;
+
+            if ($cover_image == 'assets/nocover.jpg') {
+              $cover_image_file = 'assets/nocover.jpg';
+            } else {
+              $cover_image_file = $wiki->coverFile;
+              $path = __ROOT__ . '/' . $cover_image_file;
+              $wiki->downloadFile ( $cover_image, $path );
+            }
+
+            $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, original_purchase, wiki_id, wikiUpdated) VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', '$cover_image_file', '$original_purchase', '$wiki_id', 1)";
             if (mysqli_query ( $connection, $sql )) {
               $comic_id = mysqli_insert_id ( $connection );
               $sql = "INSERT INTO users_comics (user_id, comic_id) VALUES ('$ownerID', '$comic_id')";

--- a/classes/wikiFunctions.php
+++ b/classes/wikiFunctions.php
@@ -95,11 +95,14 @@ public function wikiSearch($query, $limit) {
 			$replacement = "";
 			$this->coverURL = preg_replace($pattern, $replacement, $subject);
 			$fileparts = explode("/", $this->coverURL);
-			$this->coverFile = $fileparts[7];
+			$this->coverFile = 'images/' . $fileparts[7];
 			$this->coverFile = str_replace("%28", "", $this->coverFile);
 			$this->coverFile = str_replace("%29", "", $this->coverFile);
 			$this->coverFile = str_replace("%3F", "", $this->coverFile);
 		} else {
+			$this->coverFile = 'assets/nocover.jpg';
+			$this->coverURL = 'assets/nocover.jpg';
+			$this->noCover = true;
 			$sql = "SELECT comics.comic_id, series.series_name, comics.issue_number
 			FROM comics
 			LEFT JOIN series ON comics.series_id=series.series_id

--- a/comic.php
+++ b/comic.php
@@ -22,7 +22,7 @@
         <form method="post" action="<?php echo $filename; ?>?comic_id=<?php echo $comic->comic_id; ?>&type=edit-save">
           <div class="form-group">
             <label for="story_name">Story Name: </label>
-            <input class="form-control" name="story_name" type="text" maxlength="255" value="<?php echo $storyName; ?>" />
+            <input class="form-control" name="story_name" type="text" maxlength="255" value="<?php echo $comic->story_name; ?>" />
           </div>
           <div class="form-group">
             <label for="released_date">Release Date:</label>


### PR DESCRIPTION
- Single quotes in $plot were causing a sql error. It now runs through addslashes() first.
- added logic to comicCover() to set cover image to nocover.jpg if the API does not return one
  - **We now set the image path in the comicCover() function since nocover.jpg is in /assets/.**
  - **removed image paths in formprocess.php and add.php since they are set in the comicCover() function**
