### PR TITLE
Publishers!: The Publishing

### DIFF
--- a/add.php
+++ b/add.php
@@ -94,6 +94,7 @@
             <input type="hidden" name="series_vol" value="<?php echo $series_vol; ?>" />
             <input type="hidden" name="series_id" value="<?php echo $series_id; ?>" />
             <input type="hidden" name="issue_number" value="<?php echo $issue_number; ?>" />
+            <input type="hidden" name="publisherAPI" value="<?php echo $publisherAPI; ?>" />
             <input type="hidden" name="submitted" value="yes" />
             <div class="text-center center-block">
               <a href="#" class="btn btn-default form-back">&lt; Back</a>

--- a/admin/formprocess.php
+++ b/admin/formprocess.php
@@ -29,11 +29,13 @@
         $comic->seriesInfo ($series_id);
         $series_name = $comic->series_name;
         $series_vol = $comic->series_vol;
+        $publisherAPI = $comic->publisherShort;
+
         $issue_number = filter_input ( INPUT_POST, 'issue_number' );
         $query = $series_name . ' Vol ' . $series_vol . ' ' . $issue_number;
 
         $wiki = new wikiQuery();
-        $wiki->wikiSearch($query, 50);
+        $wiki->wikiSearch($publisherAPI, $query, 50);
         break;
       // Part two of the single issue process. Displays final fields and allows user to change details before adding to collection.
       case 'issue-add':
@@ -43,10 +45,11 @@
         $series_id = filter_input ( INPUT_POST, 'series_id' );
         $issue_number = filter_input ( INPUT_POST, 'issue_number' );
         $wiki_id = filter_input (INPUT_POST, 'wiki_id');
+        $publisherAPI = filter_input( INPUT_POST, 'publisherAPI' );
 
         $wiki = new wikiQuery ();
-        $wiki->comicCover ( $wiki_id );
-        $wiki->comicDetails ( $wiki_id );
+        $wiki->comicCover ( $publisherAPI, $wiki_id );
+        $wiki->comicDetails ( $publisherAPI, $wiki_id );
         break;
       case 'issue-submit':
         $issueSubmit = true;
@@ -121,6 +124,7 @@
         $comic->seriesInfo ($series_id);
         $series_name = $comic->series_name;
         $series_vol = $comic->series_vol;
+        $publisherAPI = $comic->publisherShort;
 
         foreach ( range ( $first_issue, $last_issue ) as $issue_number ) {
           $comic->issueCheck($series_id, $issue_number);
@@ -135,10 +139,10 @@
           } else {
             $query = $series_name . ' Vol ' . $series_vol . ' ' . $issue_number;
             $wiki = new wikiQuery();
-            $wiki->wikiSearch($query, 1);
+            $wiki->wikiSearch($publisherAPI, $query, 1);
             $wiki_id = $wiki->wiki_id;
-            $wiki->comicCover( $wiki_id );
-            $wiki->comicDetails ( $wiki_id );
+            $wiki->comicCover( $publisherAPI, $wiki_id );
+            $wiki->comicDetails ( $publisherAPI, $wiki_id );
 
             $release_date = $releaseDateArray[0] . "-" . $releaseDateArray[1] . "-" . $releaseDateArray[2];
             $plot = addslashes( $wiki->synopsis );
@@ -180,10 +184,13 @@
         $comic_id = filter_input(INPUT_GET, 'comic_id');
         $wiki_id = filter_input ( INPUT_GET, 'wiki_id' );
         $wiki = new wikiQuery ();
-        $wiki->comicCover ( $wiki_id );
-        $wiki->comicDetails ( $wiki_id );
         $comic = new comicSearch();
         $comic->issueLookup($comic_id);
+        $series_id = $comic->series_id;
+        $comic->seriesInfo ($series_id);
+        $publisherAPI = $comic->publisherShort;
+        $wiki->comicCover ($publisherAPI, $wiki_id );
+        $wiki->comicDetails ($publisherAPI, $wiki_id );
 
         $series_id = $comic->series_id;
         $series_name = $comic->series_name;

--- a/classes/functions.php
+++ b/classes/functions.php
@@ -46,6 +46,7 @@ class comicSearch {
    */
   public $series_list_result;
   public $volume_number;
+  public $publisherShort;
 
   /**
    * Looks up a single comic issue using comic_id

--- a/classes/wikiFunctions.php
+++ b/classes/wikiFunctions.php
@@ -54,12 +54,12 @@ class wikiQuery {
 	}
 
 	/**
-	 * uses an API call to marvel.wikia.com to return search results
+	 * uses an API call to wikia.com to return search results
 	 * @param string $query
 	 */
-public function wikiSearch($query, $limit) {
+public function wikiSearch($publisherAPI, $query, $limit) {
 		$comic = str_replace(' ', '+', $query);
-		$api_url = "http://marvel.wikia.com/api/v1/Search/List?query=$comic&limit=$limit&minArticleQuality=70&batch=1&namespaces=0%2C14";
+		$api_url = "http://$publisherAPI.wikia.com/api/v1/Search/List?query=$comic&limit=$limit&minArticleQuality=70&batch=1&namespaces=0%2C14";
 		$jsondata = file_get_contents($api_url);
 		$results = json_decode($jsondata, true);
 		if (count($results['items']) == 1) {
@@ -80,11 +80,11 @@ public function wikiSearch($query, $limit) {
 		}
 	}
 	/**
-	 * grabs the cover image from marvel.wikia.com using the comic's wiki_id
+	 * grabs the cover image from wikia.com using the comic's wiki_id
 	 * @param int $wiki_id
 	 */
-	public function comicCover($wiki_id) {
-		$cover_api = "http://marvel.wikia.com/api/v1/Articles/Details?ids=$wiki_id";
+	public function comicCover($publisherAPI, $wiki_id) {
+		$cover_api = "http://$publisherAPI.wikia.com/api/v1/Articles/Details?ids=$wiki_id";
 		$cover_jsondata = file_get_contents($cover_api);
 		$details_results = json_decode($cover_jsondata, true);
 		$wiki_id = $details_results['items'][$wiki_id]['id'];
@@ -118,11 +118,11 @@ public function wikiSearch($query, $limit) {
 		}
 	}
 	/**
-	 * grabs comic details from marvel.wikia.com using the comic's wiki_id
+	 * grabs comic details from wikia.com using the comic's wiki_id
 	 * @param int $wiki_id
 	 */
-	public function comicDetails($wiki_id) {
-		$details_api = "http://marvel.wikia.com/api/v1/Articles/AsSimpleJson?id=$wiki_id";
+	public function comicDetails($publisherAPI, $wiki_id) {
+		$details_api = "http://$publisherAPI.wikia.com/api/v1/Articles/AsSimpleJson?id=$wiki_id";
 		$issue_jsondata = file_get_contents($details_api);
 		$issue_results = json_decode($issue_jsondata, true);
 		$paragraphs = $issue_results['sections'][2]['content'];


### PR DESCRIPTION
API calls are no longer Marvel specific. We use the publisherShort column from the publishers table to change the subdomain in API calls to the appropriate URL for each publisher.
- Modified wikiSearch(), comicConver(), and comicDetails() to accept $publisherAPI variable.
- Modified relevant function calls to pass $publisherAPI
- declared public variable $publisherShort in functions.php. This is used for $publisherAPI and for css.

This completes work for issue #16.
