### PR TITLE
Move "original_purchase" field in database

### DIFF
--- a/add.php
+++ b/add.php
@@ -117,10 +117,10 @@
               <input class="form-control" name="released_date" size="10" maxlength="10" value="" type="date" placeholder="YYYY-MM-DD" />
             </div>
             <div class="form-group form-radio">
-              <label for="original_purchase">Purchased When Released:</label>
+              <label for="originalPurchase">Purchased When Released:</label>
               <fieldset>
-                <input name="original_purchase" id="original-yes" value="1" type="radio" /> <label for="original-yes">Yes</label>
-                <input name="original_purchase" id="original-no" value="0" type="radio" /> <label for="original-no">No</label>
+                <input name="originalPurchase" id="original-yes" value="1" type="radio" /> <label for="original-yes">Yes</label>
+                <input name="originalPurchase" id="original-no" value="0" type="radio" /> <label for="original-no">No</label>
               </fieldset>
             </div>
             <div class="plot form-group">
@@ -241,10 +241,10 @@
             <div class="col-md-12 col-xs-12">
               <div class="form-inline">
                 <div class="form-group form-radio">
-                  <label for="original_purchase">Purchased When Released</label>
+                  <label for="originalPurchase">Purchased When Released</label>
                   <fieldset>
-                    <input name="original_purchase" id="original-yes" value="1" type="radio" /> <label for="original-yes">Yes</label>
-                    <input name="original_purchase" id="original-no" value="0" type="radio" /> <label for="original-no">No</label>
+                    <input name="originalPurchase" id="original-yes" value="1" type="radio" /> <label for="original-yes">Yes</label>
+                    <input name="originalPurchase" id="original-no" value="0" type="radio" /> <label for="original-no">No</label>
                   </fieldset>
                 </div>
                 <div class="form-group">

--- a/admin/formprocess.php
+++ b/admin/formprocess.php
@@ -65,7 +65,7 @@
         $plot = addslashes ( filter_input ( INPUT_POST, 'plot' ) );
         $cover_image = filter_input ( INPUT_POST, 'cover_image' );
         $cover_image_file = filter_input ( INPUT_POST, 'cover_image_file' );
-        $original_purchase = filter_input ( INPUT_POST, 'original_purchase' );
+        $originalPurchase = filter_input ( INPUT_POST, 'originalPurchase' );
 
         if ($released_date == 0000 - 00 - 00) {
           $release_date = "";
@@ -84,7 +84,7 @@
         $comic = new comicSearch();
         $comic->issueCheck($series_id, $issue_number);
         if ($comic->issueExists == 1) {
-          $sql = "INSERT INTO users_comics (user_id, comic_id) VALUES ('$ownerID', '$comic->comic_id')";
+          $sql = "INSERT INTO users_comics (user_id, comic_id, originalPurchase) VALUES ('$ownerID', '$comic->comic_id', '$originalPurchase')";
           $comic_id = $comic->comic_id;
           if (mysqli_query ( $connection, $sql )) {
             $messageNum = 1;
@@ -93,12 +93,12 @@
             $messageNum = 51;
           }
         } else {
-          $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, original_purchase, wiki_id, wikiUpdated)
-          VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', '$cover_image_file', '$original_purchase', '$wiki_id', 1)";
+          $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, wiki_id, wikiUpdated)
+          VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', '$cover_image_file', '$wiki_id', 1)";
           if (mysqli_query ( $connection, $sql )) {
             $comic_id = mysqli_insert_id($connection);
             // Add to user_comics table
-            $sql_user = "INSERT INTO users_comics (user_id, comic_id) VALUES ('$ownerID', '$comic_id')";
+            $sql_user = "INSERT INTO users_comics (user_id, comic_id, originalPurchase) VALUES ('$ownerID', '$comic_id', '$originalPurchase')";
             if (mysqli_query ( $connection, $sql_user )) {
               $messageNum = 1;
               $sqlMessage = '<strong class="text-success">Success</strong>: Issue did not exist in the current database. Issue added to database and users collection.';
@@ -116,7 +116,7 @@
         $series_id = filter_input ( INPUT_POST, 'series_id' );
         $first_issue = filter_input ( INPUT_POST, 'first_issue' );
         $last_issue = filter_input ( INPUT_POST, 'last_issue' );
-        $original_purchase = filter_input ( INPUT_POST, 'original_purchase' );
+        $originalPurchase = filter_input ( INPUT_POST, 'originalPurchase' );
         $release_date = filter_input(INPUT_POST, 'release_date');
         $releaseDateArray = explode("-", $release_date);
 
@@ -129,7 +129,7 @@
         foreach ( range ( $first_issue, $last_issue ) as $issue_number ) {
           $comic->issueCheck($series_id, $issue_number);
           if ($comic->issueExists == 1) {
-            $sql = "INSERT INTO users_comics (user_id, comic_id) VALUES ('$ownerID', '$comic->comic_id')";
+            $sql = "INSERT INTO users_comics (user_id, comic_id, originalPurchase) VALUES ('$ownerID', '$comic->comic_id', '$originalPurchase')";
             if (mysqli_query ( $connection, $sql )) {
               $messageNum = 4;
             } else {
@@ -157,10 +157,10 @@
               $wiki->downloadFile ( $cover_image, $path );
             }
 
-            $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, original_purchase, wiki_id, wikiUpdated) VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', '$cover_image_file', '$original_purchase', '$wiki_id', 1)";
+            $sql = "INSERT INTO comics (series_id, issue_number, story_name, release_date, plot, cover_image, wiki_id, wikiUpdated) VALUES ('$series_id', '$issue_number', '$story_name', '$release_date', '$plot', '$cover_image_file', '$wiki_id', 1)";
             if (mysqli_query ( $connection, $sql )) {
               $comic_id = mysqli_insert_id ( $connection );
-              $sql = "INSERT INTO users_comics (user_id, comic_id) VALUES ('$ownerID', '$comic_id')";
+              $sql = "INSERT INTO users_comics (user_id, comic_id, originalPurchase) VALUES ('$ownerID', '$comic_id', '$originalPurchase')";
               if (mysqli_query ( $connection, $sql )) {
               } else {
                 $sqlMessage = '<strong class="text-danger">Error</strong>: ' . $sql . '<br><code>' . mysqli_error ( $connection ) . '</code>';
@@ -196,12 +196,12 @@
         $series_name = $comic->series_name;
         $series_vol = $comic->series_vol;
         $issue_number = $comic->issue_number;
-        $original_purchase = $comic->original_purchase;
+        $originalPurchase = $comic->originalPurchase;
         $release_date = $comic->release_date;
         $story_name = $comic->story_name;
         break;
       case 'edit-save':
-        $sql = "UPDATE comics SET series_id='$series_id', issue_number='$issue_number', story_name='$story_name', release_date='$release_date', plot='$plot', cover_image='images/$cover_image_file', original_purchase='$original_purchase', wikiUpdated=1 WHERE comic_id='$comic_id'";
+        $sql = "UPDATE comics SET series_id='$series_id', issue_number='$issue_number', story_name='$story_name', release_date='$release_date', plot='$plot', cover_image='images/$cover_image_file', wikiUpdated=1 WHERE comic_id='$comic_id'";
         if (mysqli_query ( $connection, $sql )) {
             $messageNum = 5;
             $sqlMessage = '<strong class="text-success">Success</strong>: ' . $sql;

--- a/classes/functions.php
+++ b/classes/functions.php
@@ -38,7 +38,7 @@ class comicSearch {
   public $comic_id;
   public $series_name;
   public $series_id;
-  public $original_purchase;
+  public $originalPurchase;
   /**
    * List of comic series in database
    *
@@ -59,7 +59,13 @@ class comicSearch {
       die ( "Connection failed: " );
     }
 
-    $sql = "SELECT * FROM comics LEFT JOIN series ON comics.series_id=series.series_id WHERE comics.comic_id = $comic_id";
+    $sql = "SELECT *
+            FROM comics
+            LEFT JOIN series
+            ON comics.series_id=series.series_id
+            LEFT JOIN users_comics
+            ON comics.comic_id=users_comics.comic_id
+            WHERE comics.comic_id = $comic_id";
     $result = $this->db_connection->query ( $sql );
     if ($result->num_rows > 0) {
       while ( $row = $result->fetch_assoc () ) {
@@ -72,7 +78,7 @@ class comicSearch {
         $wiki_id = $row['wiki_id'];
         $series_name = $row ['series_name'];
         $series_id = $row['series_id'];
-        $original_purchase = $row['original_purchase'];
+        $originalPurchase = $row['originalPurchase'];
         $series_vol = $row['series_vol'];
       }
     }
@@ -84,7 +90,7 @@ class comicSearch {
     $this->wiki_id = $wiki_id;
     $this->comic_id = $comic_id;
     $this->series_name = $series_name;
-    $this->original_purchase = $original_purchase;
+    $this->originalPurchase = $originalPurchase;
     $this->series_id = $series_id;
     $this->series_vol = $series_vol;
   }

--- a/comic.php
+++ b/comic.php
@@ -29,10 +29,10 @@
             <input class="form-control" name="released_date" size="10" maxlength="10" value="<?php if ($release_date) { echo $release_date; } ?>" type="date" placeholder="YYYY-MM-DD" />
           </div>
           <div class="form-group form-radio">
-            <label for="original_purchase">Purchased When Released:</label>
+            <label for="originalPurchase">Purchased When Released:</label>
             <fieldset>
-              <input name="original_purchase" id="original-yes" value="1" type="radio" <?php if ($original_purchase == 1) { echo 'selected'; } ?> /> <label for="original-yes">Yes</label>
-              <input name="original_purchase" id="original-no" value="0" type="radio" <?php if ($original_purchase == 0) { echo 'selected'; } ?> /> <label for="original-no">No</label>
+              <input name="originalPurchase" id="original-yes" value="1" type="radio" <?php if ($originalPurchase == 1) { echo 'selected'; } ?> /> <label for="original-yes">Yes</label>
+              <input name="originalPurchase" id="original-no" value="0" type="radio" <?php if ($originalPurchase == 0) { echo 'selected'; } ?> /> <label for="original-no">No</label>
             </fieldset>
           </div>
           <div class="plot form-group">


### PR DESCRIPTION
In addition to moving the column, it was also renamed from original_purchase to originalPurchase. All references to the column name have been updated. Form field names have also been updated.

Issue #26 
